### PR TITLE
Patch 2 - Excel Compatibility & README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Johann Hanne's php lib to write excel file
 Example for your `composer.json` file:
 
 ```
+{
     "minimum-stability": "dev",
     "repositories": [
       {
@@ -18,4 +19,6 @@ Example for your `composer.json` file:
     ],
     "require": {
         "thoroc/php_writeexcel": "master",
+    }
+}
 ```

--- a/README.md
+++ b/README.md
@@ -2,3 +2,20 @@ php_writeexcel
 ==============
 
 Johann Hanne's php lib to write excel file
+
+
+
+
+Example for your `composer.json` file:
+
+```
+    "minimum-stability": "dev",
+    "repositories": [
+      {
+        "type": "vcs",
+        "url": "https://github.com/thoroc/php_writeexcel"
+      }
+    ],
+    "require": {
+        "thoroc/php_writeexcel": "master",
+```

--- a/class.writeexcel_worksheet.inc.php
+++ b/class.writeexcel_worksheet.inc.php
@@ -113,7 +113,11 @@ class writeexcel_worksheet extends writeexcel_biffwriter {
 
         $rowmax                   = 65536; // 16384 in Excel 5
         $colmax                   = 256;
-        $strmax                   = 255;
+        //$strmax                   = 255;
+        // Ignore Excel 5 compatibility, and allow 32k of text in a cell
+        // source : http://blog.adin.pro/2013-03-13/writeexcel-php-max-size-255/
+        $strmax                   = 32767;
+
 
         $this->_name              = $name;
         $this->_index             = $index;


### PR DESCRIPTION
Modifying the allowed amount of text in a cell from 255 chars to 32k. This breaks Excel 5 compatibility, but allow modern usability.
Add an example of Composer.json example to include module from master branch.
